### PR TITLE
publish a Int8 on the fault button event

### DIFF
--- a/fault_button/cpp/vfb.cpp
+++ b/fault_button/cpp/vfb.cpp
@@ -10,6 +10,7 @@ Author: Arren Glover
 #include <string>
 #include <fstream>
 #include "../../april_msgs/yarp/rosmsg/april_msgs/Emergency.h"
+#include <yarp/rosmsg/std_msgs/Int8.h>
 
 using std::vector;
 using yarp::os::Value;
@@ -68,7 +69,8 @@ private:
 
     // ros 
     yarp::os::Node* ros_node{nullptr};
-    yarp::os::Publisher<yarp::rosmsg::april_msgs::Emergency> ros_publisher;
+    yarp::os::Publisher<yarp::rosmsg::std_msgs::Int8> ros_publisher;
+
 
     std::string calibration_path;
 
@@ -134,9 +136,8 @@ public:
 
         //ros interface
         ros_node = new yarp::os::Node("/APRIL");
-        if(!ros_publisher.topic("/sim/visualFaultButton/trigger"))
+        if(!ros_publisher.topic("/sim/vfb"))
             yWarning() << "Could not open ROS publisher - messages will not be sent to ros";
-
         // =====READ PARAMETERS=====
 
         k = rf.check("k", Value(0.01)).asFloat64();
@@ -297,15 +298,20 @@ public:
                 }
             }
             if(!autoThresh) {
-                static yarp::os::Stamp ys;
-                ys.update();
-                yarp::rosmsg::april_msgs::Emergency &rosmessage = ros_publisher.prepare();
-                rosmessage.header.seq = ys.getCount();
-                rosmessage.header.frame_id = "xmsg";
-                rosmessage.header.stamp = ys.getTime();
-                rosmessage.emergency_label = "visual_fault_button_triggered";
-                ros_publisher.setEnvelope(ys);
+                //static yarp::os::Stamp ys;
+                //ys.update();
+                //yarp::rosmsg::april_msgs::Emergency &rosmessage = ros_publisher.prepare();
+                //rosmessage.header.seq = ys.getCount();
+                //rosmessage.header.frame_id = "xmsg";
+                //rosmessage.header.stamp = ys.getTime();
+                //rosmessage.emergency_label = "visual_fault_button_triggered";
+                //ros_publisher.setEnvelope(ys);
+                //ros_publisher.write();
+
+                yarp::rosmsg::std_msgs::Int8 &rosmessage = ros_publisher.prepare();
+                rosmessage_2.data = 1;
                 ros_publisher.write();
+
             }
         }
 


### PR DESCRIPTION
Replacing the EmergencyMsg with an Int8 to fix the INESCOP issue.
We made a ROS2 wrapper to convert this Int8 in the EmergencyMsg